### PR TITLE
Modified return type to avoid implicit float to int conversion

### DIFF
--- a/lib/ImageResize.php
+++ b/lib/ImageResize.php
@@ -740,7 +740,7 @@ class ImageResize
      *
      * @param integer $expectedSize
      * @param integer $position
-     * @return float|integer
+     * @return integer
      */
     protected function getCropPosition($expectedSize, $position = self::CROPCENTER)
     {
@@ -758,7 +758,7 @@ class ImageResize
             $size = $expectedSize / 4;
             break;
         }
-        return $size;
+        return (int) $size;
     }
 
     /**


### PR DESCRIPTION
To avoid deprecation log on implicit conversion, the method **getCropPosition** should always return int.

The function, **imagecopyresampled**, expects type int on parameters src_width and src_height .
https://www.php.net/manual/en/function.imagecopyresampled.php

**Example deprecation log:**
```error
PHP message: PHP Deprecated:  Implicit conversion from float 472.5 to int loses precision in /vendor/gumlet/php-image-resize/lib/ImageResize.php on line 324'
```

PHP version: PHP 8.1.5 (cli) (built: May  3 2022 09:22:01) (NTS)